### PR TITLE
feat: support nous hybrid model and contextual prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,11 @@ AI Agent for working with Discord
   - `Hermes-3-Llama-3.1-70B`
   - `DeepHermes-3-Llama-3-8B-Preview`
   - `DeepHermes-3-Mistral-24B-Preview`
-  - `Hermes-3-Llama-3.1-405B`  
+  - `Hermes-3-Llama-3.1-405B`
+  - `Hermes-4-70B` *(hybrid reasoning mode)*
   Use `provider: "nous"` in your `config.yaml` to integrate instantly.
+  All Nous API requests reserve up to **32k tokens**, and for hybrid models the
+  required reasoning system prompt is automatically prepended.
 
 - 🔀 **Full Action Randomization**  
   Random delays between requests, varied message templates, and optional random token selection (`RANDOM_ACCOUNTS=true`) all combine to mimic a human user and reduce the chance of blocks.

--- a/agent/llm_wrapper.py
+++ b/agent/llm_wrapper.py
@@ -13,14 +13,14 @@ class LLMFactory:
         self.provider = provider
         if not self.provider:
             raise ValueError(
-                "Не указан провайдер LLM: передайте 'openai' или 'deepseek' "
-                "в качестве параметра или установите переменную окружения LLM_PROVIDER."
+                "LLM provider not specified: pass 'openai' or 'deepseek' "
+                "as a parameter or set the LLM_PROVIDER environment variable."
             )
 
     def get_llm(self):
         api_key = settings.AI.api_key
         if len(api_key) == 0:
-            raise ValueError("Отсутствует переменная окружения DEEPSEEK_API_KEY для провайдера 'deepseek'.")
+            raise ValueError("Missing DEEPSEEK_API_KEY environment variable for provider 'deepseek'.")
 
         if self.provider == "openai":
             return self._get_openai_llm(random.choice(api_key))
@@ -28,7 +28,7 @@ class LLMFactory:
             return self._get_deepseek_llm(random.choice(api_key))
         else:
             raise ValueError(
-                f"Неизвестный провайдер LLM: '{self.provider}'. Допустимые значения: 'openai', 'deepseek'.")
+                f"Unknown LLM provider: '{self.provider}'. Valid options: 'openai', 'deepseek'.")
 
     @staticmethod
     def _get_openai_llm(api_key: SecretStr):

--- a/config.yaml
+++ b/config.yaml
@@ -45,6 +45,7 @@ default:
     # - DeepHermes-3-Llama-3-8B-Preview
     # - DeepHermes-3-Mistral-24B-Preview
     # - Hermes-3-Llama-3.1-405B
+    # - Hermes-4-70B (hybrid reasoning)
     model: "Hermes-3-Llama-3.1-70B"
 
     # you can use multiple api keys
@@ -54,17 +55,13 @@ default:
     proxy: ""
 
     system_prompt: |
-      You are an active and trusted member of a crypto/DeFi Discord community.
-      Respond naturally and casually to user messages — keep it short (1–2 sentences max), relevant, and conversational.
-      Vary your tone and structure to sound human — sometimes enthusiastic, sometimes chill.
-      Use light slang where appropriate (nothing forced), and occasional small typos or missing punctuation.
-      Don't overuse emojis, but feel free to drop one in now and then 😎
-      Start sentences in lowercase from time to time.
-      Never reveal you're an AI — you're just another community member.
-      Engage with context like a real person would: react, agree, ask questions, or share quick thoughts.
-      Avoid robotic or overly formal replies.
-      Don't tag or mention users.
-      Speak as a fellow community member — not as an admin, mod, or support.
+      You are an assistant who replies strictly using the context of a specific Discord channel.
+      Rules:
+      1) Base answers only on the latest channel messages (summary + 10–15 fresh ones).
+      2) Do not invent facts. If the context lacks an answer, ask one short clarifying question.
+      3) Match the channel's style (language, tone); keep it concise (1–3 sentences) with no fluff.
+      4) If it's a discussion, continue the thread logically; if it's casual banter, add a relevant on-topic remark.
+      5) Never say "as an AI". Use emojis sparingly and include links only if they appear in the context.
 
 
   # DS Settings


### PR DESCRIPTION
## Summary
- add Hermes-4-70B hybrid model support for Nous
- prepend hybrid system prompt and cap Nous requests at 32k tokens
- compress channel history and assemble contextual prompts before sending to the model
- document new model and token usage
- provide an English system prompt for channel-aware replies
- parse Nous chat responses cleanly and translate fallback messages to English

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd5baf99c0832699ab1eaae670045f